### PR TITLE
Use the `filterSuggestions` provider property

### DIFF
--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -10,6 +10,11 @@ cssDocsURL = "https://developer.mozilla.org/en-US/docs/Web/CSS"
 module.exports =
   selector: '.source.css'
 
+  # Tell autocomplete to fuzzy filter the results of getSuggestions(). We are
+  # still filtering by the first character of the prefix in this provider for
+  # efficiency.
+  filterSuggestions: true
+
   getSuggestions: (request) ->
     completions = null
     isCompletingPseudoSelector = @isCompletingPseudoSelector(request)
@@ -102,8 +107,7 @@ module.exports =
 
     completions = []
     if @isPropertyValuePrefix(prefix)
-      lowerCasePrefix = prefix.toLowerCase()
-      for value in values when value.indexOf(lowerCasePrefix) is 0
+      for value in values when firstCharsEqual(value, prefix)
         completions.push(@buildPropertyValueCompletion(value, property))
     else
       for value in values
@@ -124,13 +128,8 @@ module.exports =
   getPropertyNameCompletions: ({bufferPosition, editor}) ->
     prefix = @getPropertyNamePrefix(bufferPosition, editor)
     completions = []
-    if prefix
-      lowerCasePrefix = prefix.toLowerCase()
-      for property, options of @properties when property.indexOf(lowerCasePrefix) is 0
-        completions.push(@buildPropertyNameCompletion(property, prefix, options))
-    else
-      for property, options of @properties
-        completions.push(@buildPropertyNameCompletion(property, '', options))
+    for property, options of @properties when not prefix or firstCharsEqual(property, prefix)
+      completions.push(@buildPropertyNameCompletion(property, prefix, options))
     completions
 
   buildPropertyNameCompletion: (propertyName, prefix, {description}) ->
@@ -150,8 +149,7 @@ module.exports =
     return null unless prefix
 
     completions = []
-    lowerCasePrefix = prefix.toLowerCase()
-    for pseudoSelector, options of @pseudoSelectors when pseudoSelector.indexOf(lowerCasePrefix) is 0
+    for pseudoSelector, options of @pseudoSelectors when firstCharsEqual(pseudoSelector, prefix)
       completions.push(@buildPseudoSelectorCompletion(pseudoSelector, prefix, options))
     completions
 
@@ -175,8 +173,7 @@ module.exports =
   getTagCompletions: ({bufferPosition, editor, prefix}) ->
     completions = []
     if prefix
-      lowerCasePrefix = prefix.toLowerCase()
-      for tag in @tags when tag.indexOf(lowerCasePrefix) is 0
+      for tag in @tags when firstCharsEqual(tag, prefix)
         completions.push(@buildTagCompletion(tag))
     completions
 
@@ -187,3 +184,6 @@ module.exports =
 
 hasScope = (scopesArray, scope) ->
   scopesArray.indexOf(scope) isnt -1
+
+firstCharsEqual = (str1, str2) ->
+  str1[0].toLowerCase() is str2[0].toLowerCase()

--- a/spec/provider-spec.coffee
+++ b/spec/provider-spec.coffee
@@ -111,36 +111,14 @@ describe "CSS property name and value autocompletions", ->
 
         editor.setText """
           body {
-            border-
+            bord
           }
         """
-        editor.setCursorBufferPosition([1, 9])
+        editor.setCursorBufferPosition([1, 6])
         completions = getCompletions()
-        expect(completions.length).toBe 32
-        expect(completions[0].text).toBe 'border-radius: '
-        expect(completions[0].displayText).toBe 'border-radius'
-        expect(completions[0].replacementPrefix).toBe 'border-'
-
-        editor.setText """
-          body {
-            border-bot
-          }
-        """
-        editor.setCursorBufferPosition([1, 12])
-        completions = getCompletions()
-        expect(completions.length).toBe 6
-        expect(completions[0].text).toBe 'border-bottom: '
-        expect(completions[1].text).toBe 'border-bottom-color: '
-
-        editor.setText """
-          body {
-            border-bottom-
-          }
-        """
-        editor.setCursorBufferPosition([1, 16])
-        completions = getCompletions()
-        expect(completions.length).toBe 5
-        expect(completions[0].text).toBe 'border-bottom-color: '
+        expect(completions[0].text).toBe 'border: '
+        expect(completions[0].displayText).toBe 'border'
+        expect(completions[0].replacementPrefix).toBe 'bord'
 
       it "triggers autocomplete when an property name has been inserted", ->
         spyOn(atom.commands, 'dispatch')
@@ -235,11 +213,11 @@ describe "CSS property name and value autocompletions", ->
           """
           editor.setCursorBufferPosition([0, 2])
           completions = getCompletions()
-          expect(completions.length).toBe 2
+          expect(completions.length).toBe 7
           expect(completions[0].text).toBe 'canvas'
           expect(completions[0].type).toBe 'tag'
           expect(completions[0].description).toBe 'Selector for <canvas> elements'
-          expect(completions[1].text).toBe 'caption'
+          expect(completions[1].text).toBe 'code'
 
           editor.setText """
             canvas,ca {
@@ -247,7 +225,7 @@ describe "CSS property name and value autocompletions", ->
           """
           editor.setCursorBufferPosition([0, 9])
           completions = getCompletions()
-          expect(completions.length).toBe 2
+          expect(completions.length).toBe 7
           expect(completions[0].text).toBe 'canvas'
 
           editor.setText """
@@ -256,7 +234,7 @@ describe "CSS property name and value autocompletions", ->
           """
           editor.setCursorBufferPosition([0, 9])
           completions = getCompletions()
-          expect(completions.length).toBe 2
+          expect(completions.length).toBe 7
           expect(completions[0].text).toBe 'canvas'
 
           editor.setText """
@@ -265,7 +243,7 @@ describe "CSS property name and value autocompletions", ->
           """
           editor.setCursorBufferPosition([0, 10])
           completions = getCompletions()
-          expect(completions.length).toBe 2
+          expect(completions.length).toBe 7
           expect(completions[0].text).toBe 'canvas'
 
         it "does not autocompletes when prefix is preceded by class or id char", ->
@@ -299,7 +277,9 @@ describe "CSS property name and value autocompletions", ->
             expect(text.length).toBeGreaterThan 0
             expect(completion.type).toBe 'pseudo-selector'
 
-        it "autocompletes with a prefix", ->
+        # TODO: Enable these tests when we can enable autocomplete and test the
+        # entire path.
+        xit "autocompletes with a prefix", ->
           editor.setText """
             div:f {
             }
@@ -312,7 +292,7 @@ describe "CSS property name and value autocompletions", ->
           expect(completions[0].description.length).toBeGreaterThan 0
           expect(completions[0].descriptionMoreURL.length).toBeGreaterThan 0
 
-        it "autocompletes with arguments", ->
+        xit "autocompletes with arguments", ->
           editor.setText """
             div:nth {
             }
@@ -325,7 +305,7 @@ describe "CSS property name and value autocompletions", ->
           expect(completions[0].description.length).toBeGreaterThan 0
           expect(completions[0].descriptionMoreURL.length).toBeGreaterThan 0
 
-        it "autocompletes when nothing precedes the colon", ->
+        xit "autocompletes when nothing precedes the colon", ->
           editor.setText """
             :f {
             }


### PR DESCRIPTION
Suggestions are now fuzzy filtered in autocomplete. This provider just checks that the first char of the prefix and suggestion match as a first line of defense.

This makes the tests a little awkward because we no longer do the filtering. I'd like to enable autocomplete-plus and test the entire path, but that is not possible on CI at this time.
