### PR TITLE
Add support for SASS

### DIFF
--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -153,7 +153,12 @@ module.exports =
     line = editor.getTextInRange([[bufferPosition.row, 0], bufferPosition])
     propertyNamePrefixPattern.exec(line)?[0]
 
-  getPropertyNameCompletions: ({bufferPosition, editor}) ->
+  getPropertyNameCompletions: ({bufferPosition, editor, scopeDescriptor}) ->
+    # Don't autocomplete property names in SASS on root level
+    scopes = scopeDescriptor.getScopesArray()
+    line = editor.getTextInRange([[bufferPosition.row, 0], bufferPosition])
+    return [] if hasScope(scopes, 'source.sass') and not line.match(/^(\s|\t)/)
+
     prefix = @getPropertyNamePrefix(bufferPosition, editor)
     completions = []
     for property, options of @properties when not prefix or firstCharsEqual(property, prefix)

--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -8,8 +8,8 @@ tagSelectorPrefixPattern = /(^|\s|,)([a-z]+)?$/
 cssDocsURL = "https://developer.mozilla.org/en-US/docs/Web/CSS"
 
 module.exports =
-  selector: '.source.css'
-  disableForSelector: '.source.css .comment, .source.css .string'
+  selector: '.source.css, .source.sass'
+  disableForSelector: '.source.css .comment, .source.css .string, .source.sass .comment, .source.sass .string'
 
   # Tell autocomplete to fuzzy filter the results of getSuggestions(). We are
   # still filtering by the first character of the prefix in this provider for
@@ -18,15 +18,21 @@ module.exports =
 
   getSuggestions: (request) ->
     completions = null
-    isCompletingPseudoSelector = @isCompletingPseudoSelector(request)
-    if isCompletingPseudoSelector
-      completions = @getPseudoSelectorCompletions(request)
-    else if @isCompletingValue(request)
-      completions = @getPropertyValueCompletions(request)
-    else if @isCompletingName(request)
-      completions = @getPropertyNameCompletions(request)
+    scopes = request.scopeDescriptor.getScopesArray()
+    isSass = hasScope(scopes, 'source.sass')
 
-    if @isCompletingTagSelector(request)
+    if @isCompletingValue(request)
+      completions = @getPropertyValueCompletions(request)
+    else if @isCompletingPseudoSelector(request)
+      completions = @getPseudoSelectorCompletions(request)
+    else
+      if isSass and @isCompletingNameOrTag(request)
+        completions = completions = @getPropertyNameCompletions(request)
+          .concat(@getTagCompletions(request))
+      else if not isSass and @isCompletingName(request)
+        completions = @getPropertyNameCompletions(request)
+
+    if not isSass and @isCompletingTagSelector(request)
       tagCompletions = @getTagCompletions(request)
       if tagCompletions?.length
         completions ?= []
@@ -46,15 +52,29 @@ module.exports =
       {@pseudoSelectors, @properties, @tags} = JSON.parse(content) unless error?
       return
 
-  isCompletingValue: ({scopeDescriptor}) ->
+  isCompletingValue: ({scopeDescriptor, bufferPosition, prefix, editor}) ->
     scopes = scopeDescriptor.getScopesArray()
-    (scopes.indexOf('meta.property-value.css') isnt -1 and scopes.indexOf('punctuation.separator.key-value.css') is -1) or
-    (scopes.indexOf('meta.property-value.scss') isnt -1 and scopes.indexOf('punctuation.separator.key-value.scss') is -1)
+
+    previousBufferPosition = [bufferPosition.row, Math.max(0, bufferPosition.column - prefix.length - 1)]
+    previousScopes = editor.scopeDescriptorForBufferPosition(previousBufferPosition)
+    previousScopesArray = previousScopes.getScopesArray()
+
+    (hasScope(scopes, 'meta.property-value.css') and not hasScope(scopes, 'punctuation.separator.key-value.css')) or
+    (hasScope(scopes, 'meta.property-value.scss') and not hasScope(scopes, 'punctuation.separator.key-value.scss')) or
+    (hasScope(scopes, 'source.sass') and (hasScope(scopes, 'meta.property-value.sass') or
+      (not hasScope(previousScopesArray, "entity.name.tag.css.sass") and prefix.trim() is ":")
+    ))
 
   isCompletingName: ({scopeDescriptor})->
     scopes = scopeDescriptor.getScopesArray()
-    scopes.indexOf('meta.property-list.css') isnt -1 or
-    scopes.indexOf('meta.property-list.scss') isnt -1
+    hasScope(scopes, 'meta.property-list.css') or
+    hasScope(scopes, 'meta.property-list.scss')
+
+  isCompletingNameOrTag: ({scopeDescriptor}) ->
+    scopes = scopeDescriptor.getScopesArray()
+    return hasScope(scopes, 'meta.selector.css') and
+      not hasScope(scopes, 'entity.other.attribute-name.id.css.sass') and
+      not hasScope(scopes, 'entity.other.attribute-name.class.sass')
 
   isCompletingTagSelector: ({editor, scopeDescriptor, bufferPosition}) ->
     scopes = scopeDescriptor.getScopesArray()
@@ -71,9 +91,9 @@ module.exports =
 
   isCompletingPseudoSelector: ({editor, scopeDescriptor, bufferPosition}) ->
     scopes = scopeDescriptor.getScopesArray()
-    if hasScope(scopes, 'meta.selector.css')
+    if hasScope(scopes, 'meta.selector.css') and not hasScope(scopes, 'source.sass')
       true
-    else if hasScope(scopes, 'source.css.scss') or hasScope(scopes, 'source.css.less')
+    else if hasScope(scopes, 'source.css.scss') or hasScope(scopes, 'source.css.less') or hasScope(scopes, 'source.sass')
       prefix = @getPseudoSelectorPrefix(editor, bufferPosition)
       if prefix
         previousBufferPosition = [bufferPosition.row, Math.max(0, bufferPosition.column - prefix.length - 1)]
@@ -101,26 +121,33 @@ module.exports =
       row--
     return
 
-  getPropertyValueCompletions: ({bufferPosition, editor, prefix}) ->
+  getPropertyValueCompletions: ({bufferPosition, editor, prefix, scopeDescriptor}) ->
     property = @getPreviousPropertyName(bufferPosition, editor)
     values = @properties[property]?.values
     return null unless values?
 
+    scopes = scopeDescriptor.getScopesArray()
+
     completions = []
     if @isPropertyValuePrefix(prefix)
       for value in values when firstCharsEqual(value, prefix)
-        completions.push(@buildPropertyValueCompletion(value, property))
+        completions.push(@buildPropertyValueCompletion(value, property, scopes))
     else
       for value in values
-        completions.push(@buildPropertyValueCompletion(value, property))
+        completions.push(@buildPropertyValueCompletion(value, property, scopes))
     completions
 
-  buildPropertyValueCompletion: (value, propertyName) ->
-    type: 'value'
-    text: "#{value};"
-    displayText: value
-    description: "#{value} value for the #{propertyName} property"
-    descriptionMoreURL: "#{cssDocsURL}/#{propertyName}#Values"
+  buildPropertyValueCompletion: (value, propertyName, scopes) ->
+    text = value
+    text += ';' unless hasScope(scopes, 'source.sass')
+
+    {
+      type: 'value'
+      text: text
+      displayText: value
+      description: "#{value} value for the #{propertyName} property"
+      descriptionMoreURL: "#{cssDocsURL}/#{propertyName}#Values"
+    }
 
   getPropertyNamePrefix: (bufferPosition, editor) ->
     line = editor.getTextInRange([[bufferPosition.row, 0], bufferPosition])

--- a/spec/provider-spec.coffee
+++ b/spec/provider-spec.coffee
@@ -347,3 +347,187 @@ describe "CSS property name and value autocompletions", ->
           completions = getCompletions()
           expect(completions.length).toBe 5
           expect(completions[0].text).toBe ':first'
+
+  describe "SASS files", ->
+    beforeEach ->
+      waitsForPromise -> atom.packages.activatePackage('language-sass')
+      waitsForPromise -> atom.workspace.open('test.sass')
+      runs -> editor = atom.workspace.getActiveTextEditor()
+
+    it "autocompletes property names with a prefix", ->
+      editor.setText """
+        body
+          d
+      """
+      editor.setCursorBufferPosition([1, 3])
+      completions = getCompletions()
+      expect(completions[0].text).toBe 'display: '
+      expect(completions[0].displayText).toBe 'display'
+      expect(completions[0].type).toBe 'property'
+      expect(completions[0].replacementPrefix).toBe 'd'
+      expect(completions[0].description.length).toBeGreaterThan 0
+      expect(completions[0].descriptionMoreURL.length).toBeGreaterThan 0
+      expect(completions[1].text).toBe 'direction: '
+      expect(completions[1].displayText).toBe 'direction'
+      expect(completions[1].type).toBe 'property'
+      expect(completions[1].replacementPrefix).toBe 'd'
+
+      editor.setText """
+        body
+          D
+      """
+      editor.setCursorBufferPosition([1, 3])
+      completions = getCompletions()
+      expect(completions.length).toBe 11
+      expect(completions[0].text).toBe 'display: '
+      expect(completions[1].text).toBe 'direction: '
+      expect(completions[1].replacementPrefix).toBe 'D'
+
+      editor.setText """
+        body
+          d:
+      """
+      editor.setCursorBufferPosition([1, 3])
+      completions = getCompletions()
+      expect(completions[0].text).toBe 'display: '
+      expect(completions[1].text).toBe 'direction: '
+
+      editor.setText """
+        body
+          bord
+      """
+      editor.setCursorBufferPosition([1, 6])
+      completions = getCompletions()
+      expect(completions[0].text).toBe 'border: '
+      expect(completions[0].displayText).toBe 'border'
+      expect(completions[0].replacementPrefix).toBe 'bord'
+
+    it "triggers autocomplete when an property name has been inserted", ->
+      spyOn(atom.commands, 'dispatch')
+      suggestion = {type: 'property', text: 'whatever'}
+      provider.onDidInsertSuggestion({editor, suggestion})
+
+      advanceClock 1
+      expect(atom.commands.dispatch).toHaveBeenCalled()
+
+      args = atom.commands.dispatch.mostRecentCall.args
+      expect(args[0].tagName.toLowerCase()).toBe 'atom-text-editor'
+      expect(args[1]).toBe 'autocomplete-plus:activate'
+
+    it "autocompletes property values without a prefix", ->
+      editor.setText """
+        body
+          display:
+      """
+      editor.setCursorBufferPosition([1, 10])
+      completions = getCompletions()
+      expect(completions.length).toBe 21
+      for completion in completions
+        expect(completion.text.length).toBeGreaterThan 0
+        expect(completion.description.length).toBeGreaterThan 0
+        expect(completion.descriptionMoreURL.length).toBeGreaterThan 0
+
+      editor.setText """
+        body
+          display:
+      """
+      editor.setCursorBufferPosition([2, 0])
+      completions = getCompletions()
+      expect(completions.length).toBe 21
+      for completion in completions
+        expect(completion.text.length).toBeGreaterThan 0
+
+    it "autocompletes property values with a prefix", ->
+      editor.setText """
+        body
+          display: i
+      """
+      editor.setCursorBufferPosition([1, 12])
+      completions = getCompletions()
+      expect(completions[0].text).toBe 'inline'
+      expect(completions[0].description.length).toBeGreaterThan 0
+      expect(completions[0].descriptionMoreURL.length).toBeGreaterThan 0
+      expect(completions[1].text).toBe 'inline-block'
+      expect(completions[2].text).toBe 'inline-flex'
+      expect(completions[3].text).toBe 'inline-grid'
+      expect(completions[4].text).toBe 'inline-table'
+      expect(completions[5].text).toBe 'inherit'
+
+      editor.setText """
+        body
+          display: I
+      """
+      editor.setCursorBufferPosition([1, 12])
+      completions = getCompletions()
+      expect(completions.length).toBe 6
+      expect(completions[0].text).toBe 'inline'
+      expect(completions[1].text).toBe 'inline-block'
+      expect(completions[2].text).toBe 'inline-flex'
+      expect(completions[3].text).toBe 'inline-grid'
+      expect(completions[4].text).toBe 'inline-table'
+      expect(completions[5].text).toBe 'inherit'
+
+    describe "tags", ->
+      it "autocompletes with a prefix", ->
+        editor.setText """
+          ca
+        """
+        editor.setCursorBufferPosition([0, 2])
+        completions = getCompletions()
+        expect(completions.length).toBe 7
+        expect(completions[0].text).toBe 'canvas'
+        expect(completions[0].type).toBe 'tag'
+        expect(completions[0].description).toBe 'Selector for <canvas> elements'
+        expect(completions[1].text).toBe 'code'
+
+        editor.setText """
+          canvas,ca
+        """
+        editor.setCursorBufferPosition([0, 9])
+        completions = getCompletions()
+        expect(completions.length).toBe 7
+        expect(completions[0].text).toBe 'canvas'
+
+        editor.setText """
+          canvas ca
+        """
+        editor.setCursorBufferPosition([0, 9])
+        completions = getCompletions()
+        expect(completions.length).toBe 7
+        expect(completions[0].text).toBe 'canvas'
+
+        editor.setText """
+          canvas, ca
+        """
+        editor.setCursorBufferPosition([0, 10])
+        completions = getCompletions()
+        expect(completions.length).toBe 7
+        expect(completions[0].text).toBe 'canvas'
+
+      it "does not autocomplete when prefix is preceded by class or id char", ->
+        editor.setText """
+          .ca
+        """
+        editor.setCursorBufferPosition([0, 3])
+        completions = getCompletions()
+        expect(completions).toBe null
+
+        editor.setText """
+          #ca
+        """
+        editor.setCursorBufferPosition([0, 3])
+        completions = getCompletions()
+        expect(completions).toBe null
+
+    describe "pseudo selectors", ->
+      it "autocompletes without a prefix", ->
+        editor.setText """
+          div:
+        """
+        editor.setCursorBufferPosition([0, 4])
+        completions = getCompletions()
+        expect(completions.length).toBe 43
+        for completion in completions
+          text = (completion.text or completion.snippet)
+          expect(text.length).toBeGreaterThan 0
+          expect(completion.type).toBe 'pseudo-selector'


### PR DESCRIPTION
Unfortunately things get quite dirty here, since we need to handle stuff differently for SASS due to its bracket-less and indentation-based syntax. Now that `autocomplete-css` is handling multiple pre-processors, we should consider creating separate classes for each language to clean things up. I guess this is a good (and working) start though.
