### PR TITLE
Fix property completions in some cases

### DIFF
--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -189,13 +189,15 @@ module.exports =
     line = editor.getTextInRange([[bufferPosition.row, 0], bufferPosition])
     propertyNamePrefixPattern.exec(line)?[0]
 
-  getPropertyNameCompletions: ({bufferPosition, editor, scopeDescriptor}) ->
+  getPropertyNameCompletions: ({bufferPosition, editor, scopeDescriptor, activatedManually}) ->
     # Don't autocomplete property names in SASS on root level
     scopes = scopeDescriptor.getScopesArray()
     line = editor.getTextInRange([[bufferPosition.row, 0], bufferPosition])
     return [] if hasScope(scopes, 'source.sass') and not line.match(/^(\s|\t)/)
 
     prefix = @getPropertyNamePrefix(bufferPosition, editor)
+    return null unless activatedManually or prefix
+
     completions = []
     for property, options of @properties when not prefix or firstCharsEqual(property, prefix)
       completions.push(@buildPropertyNameCompletion(property, prefix, options))

--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -70,25 +70,40 @@ module.exports =
     scopes = scopeDescriptor.getScopesArray()
     lineLength = editor.lineTextForBufferRow(bufferPosition.row).length
     isAtTerminator = prefix.endsWith(';')
+    isAtParentSymbol = prefix.endsWith('&')
     isInPropertyList = not isAtTerminator and
       (hasScope(scopes, 'meta.property-list.css') or
       hasScope(scopes, 'meta.property-list.scss'))
+
+    return false unless isInPropertyList
+    return false if isAtParentSymbol
+
+    previousBufferPosition = [bufferPosition.row, Math.max(0, bufferPosition.column - prefix.length - 1)]
+    previousScopes = editor.scopeDescriptorForBufferPosition(previousBufferPosition)
+    previousScopesArray = previousScopes.getScopesArray()
+
+    return false if hasScope(previousScopesArray, 'entity.other.attribute-name.class.css') or
+      hasScope(previousScopesArray, 'entity.other.attribute-name.id.css') or
+      hasScope(previousScopesArray, 'entity.other.attribute-name.id') or
+      hasScope(previousScopesArray, 'entity.other.attribute-name.parent-selector.css') or
+      hasScope(previousScopesArray, 'entity.name.tag.reference.scss') or
+      hasScope(previousScopesArray, 'entity.name.tag.scss')
 
     isAtBeginScopePunctuation = hasScope(scopes, 'punctuation.section.property-list.begin.css') or
       hasScope(scopes, 'punctuation.section.property-list.begin.scss')
     isAtEndScopePunctuation = hasScope(scopes, 'punctuation.section.property-list.end.css') or
       hasScope(scopes, 'punctuation.section.property-list.end.scss')
 
-    if isInPropertyList and isAtBeginScopePunctuation
+    if isAtBeginScopePunctuation
       # * Disallow here: `canvas,|{}`
       # * Allow here: `canvas,{| }`
       prefix.endsWith('{')
-    else if isInPropertyList and isAtEndScopePunctuation
+    else if isAtEndScopePunctuation
       # * Disallow here: `canvas,{}|`
       # * Allow here: `canvas,{ |}`
       not prefix.endsWith('}')
     else
-      isInPropertyList
+      true
 
   isCompletingNameOrTag: ({scopeDescriptor}) ->
     scopes = scopeDescriptor.getScopesArray()

--- a/spec/provider-spec.coffee
+++ b/spec/provider-spec.coffee
@@ -471,7 +471,9 @@ describe "CSS property name and value autocompletions", ->
           expect(completions[1].text).toBe 'direction: '
           expect(completions[2].text).toBe 'div'
 
-        it "autocompletes pseudo selectors when nested in LESS and SCSS files", ->
+        # FIXME: This is an issue with the grammar. It thinks nested
+        # pseudo-selectors are meta.property-value.scss/less
+        xit "autocompletes pseudo selectors when nested in LESS and SCSS files", ->
           editor.setText """
             .some-class {
               .a:f

--- a/spec/provider-spec.coffee
+++ b/spec/provider-spec.coffee
@@ -495,13 +495,43 @@ describe "CSS property name and value autocompletions", ->
           expect(completions.length).toBe 5
           expect(completions[0].text).toBe ':first'
 
-        it "does not show property names when in a selector", ->
+        it "does not show property names when in a class selector", ->
           editor.setText """
             body {
-              .something,
+              .a
             }
           """
-          editor.setCursorBufferPosition([1, 13])
+          editor.setCursorBufferPosition([1, 4])
+          completions = getCompletions()
+          expect(completions).toBe null
+
+        it "does not show property names when in an id selector", ->
+          editor.setText """
+            body {
+              #a
+            }
+          """
+          editor.setCursorBufferPosition([1, 4])
+          completions = getCompletions()
+          expect(completions).toBe null
+
+        it "does not show property names when in a parent selector", ->
+          editor.setText """
+            body {
+              &
+            }
+          """
+          editor.setCursorBufferPosition([1, 4])
+          completions = getCompletions()
+          expect(completions).toBe null
+
+        it "does not show property names when in a parent selector with a prefix", ->
+          editor.setText """
+            body {
+              &a
+            }
+          """
+          editor.setCursorBufferPosition([1, 4])
           completions = getCompletions()
           expect(completions).toBe null
 

--- a/spec/provider-spec.coffee
+++ b/spec/provider-spec.coffee
@@ -12,7 +12,7 @@ packagesToTest =
 describe "CSS property name and value autocompletions", ->
   [editor, provider] = []
 
-  getCompletions = ->
+  getCompletions = (options={}) ->
     cursor = editor.getLastCursor()
     start = cursor.getBeginningOfCurrentWordBufferPosition()
     end = cursor.getBufferPosition()
@@ -22,6 +22,7 @@ describe "CSS property name and value autocompletions", ->
       bufferPosition: end
       scopeDescriptor: cursor.getScopeDescriptor()
       prefix: prefix
+      activatedManually: options.activatedManually ? true
     provider.getSuggestions(request)
 
   beforeEach ->
@@ -54,19 +55,29 @@ describe "CSS property name and value autocompletions", ->
           expect(completion.text.length).toBeGreaterThan 0
           expect(completion.type).toBe 'tag'
 
-      it "autocompletes property names without a prefix", ->
+      it "autocompletes property names without a prefix when activated manually", ->
         editor.setText """
           body {
 
           }
         """
         editor.setCursorBufferPosition([1, 0])
-        completions = getCompletions()
+        completions = getCompletions(activatedManually: true)
         expect(completions.length).toBe 209
         for completion in completions
           expect(completion.text.length).toBeGreaterThan 0
           expect(completion.type).toBe 'property'
           expect(completion.descriptionMoreURL.length).toBeGreaterThan 0
+
+      it "does not autocomplete property names without a prefix when not activated manually", ->
+        editor.setText """
+          body {
+
+          }
+        """
+        editor.setCursorBufferPosition([1, 0])
+        completions = getCompletions(activatedManually: false)
+        expect(completions).toBe null
 
       it "autocompletes property names with a prefix", ->
         editor.setText """

--- a/spec/provider-spec.coffee
+++ b/spec/provider-spec.coffee
@@ -452,8 +452,8 @@ describe "CSS property name and value autocompletions", ->
           expect(completions[0].text).toBe ':first'
 
   Object.keys(packagesToTest).forEach (packageLabel) ->
-    if packageLabel[name] is 'language-css'
-      describe "#{packageLabel[name]} files", ->
+    if packagesToTest[packageLabel].name in ['language-sass', 'language-less']
+      describe "#{packageLabel} files", ->
         beforeEach ->
           waitsForPromise -> atom.packages.activatePackage(packagesToTest[packageLabel].name)
           waitsForPromise -> atom.workspace.open(packagesToTest[packageLabel].file)
@@ -467,11 +467,9 @@ describe "CSS property name and value autocompletions", ->
           """
           editor.setCursorBufferPosition([1, 4])
           completions = getCompletions()
-          expect(completions.length).toBe 4
-          expect(completions[0].text).toBe 'direction: '
-          expect(completions[1].text).toBe 'display: '
-          expect(completions[2].text).toBe 'dialog'
-          expect(completions[3].text).toBe 'div'
+          expect(completions[0].text).toBe 'display: '
+          expect(completions[1].text).toBe 'direction: '
+          expect(completions[2].text).toBe 'div'
 
         it "autocompletes pseudo selectors when nested in LESS and SCSS files", ->
           editor.setText """

--- a/spec/provider-spec.coffee
+++ b/spec/provider-spec.coffee
@@ -482,6 +482,16 @@ describe "CSS property name and value autocompletions", ->
           expect(completions.length).toBe 5
           expect(completions[0].text).toBe ':first'
 
+        it "does not show property names when in a selector", ->
+          editor.setText """
+            body {
+              .something,
+            }
+          """
+          editor.setCursorBufferPosition([1, 13])
+          completions = getCompletions()
+          expect(completions).toBe null
+
   describe "SASS files", ->
     beforeEach ->
       waitsForPromise -> atom.packages.activatePackage('language-sass')


### PR DESCRIPTION
Completing properties is pretty eager, and it often pops up when it's unnecessary. This PR does 2 things
1. Does not suggest property names without a prefix _unless_ manually triggered.
2. Does not suggest property names when a user is typing in a nested selector in less and scss

Closes https://github.com/atom/autocomplete-plus/issues/513
