### PR TITLE
Uncaught TypeError: Cannot read property 'concat' of null

### DIFF
--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -27,8 +27,7 @@ module.exports =
     else if @isCompletingPseudoSelector(request)
       completions = @getPseudoSelectorCompletions(request)
     else
-      {prefix} = request
-      if isSass and @isCompletingNameOrTag(request) and not @isEmptyClassOrIdPrefix(prefix) and not @isCommaPrefix(prefix)
+      if isSass and @isCompletingNameOrTag(request)
         completions = @getPropertyNameCompletions(request)
           .concat(@getTagCompletions(request))
       else if not isSass and @isCompletingName(request)
@@ -106,9 +105,10 @@ module.exports =
     else
       true
 
-  isCompletingNameOrTag: ({scopeDescriptor}) ->
+  isCompletingNameOrTag: ({scopeDescriptor, prefix}) ->
     scopes = scopeDescriptor.getScopesArray()
-    return hasScope(scopes, 'meta.selector.css') and
+    return @isPropertyNamePrefix(prefix) and
+      hasScope(scopes, 'meta.selector.css') and
       not hasScope(scopes, 'entity.other.attribute-name.id.css.sass') and
       not hasScope(scopes, 'entity.other.attribute-name.class.sass')
 
@@ -149,13 +149,9 @@ module.exports =
     prefix = prefix.trim()
     prefix.length > 0 and prefix isnt ':'
 
-  isEmptyClassOrIdPrefix: (prefix) ->
+  isPropertyNamePrefix: (prefix) ->
     prefix = prefix.trim()
-    prefix.length > 0 and (prefix is '.' or prefix is '#')
-
-  isCommaPrefix: (prefix) ->
-    prefix = prefix.trim()
-    prefix.length > 0 and prefix is ','
+    prefix.length > 0 and prefix.match(/\w/)
 
   getImportantPrefix: (editor, bufferPosition) ->
     line = editor.getTextInRange([[bufferPosition.row, 0], bufferPosition])

--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -27,8 +27,8 @@ module.exports =
     else if @isCompletingPseudoSelector(request)
       completions = @getPseudoSelectorCompletions(request)
     else
-      if isSass and @isCompletingNameOrTag(request)
-        completions = completions = @getPropertyNameCompletions(request)
+      if isSass and @isCompletingNameOrTag(request) and not @isEmptyClassOrIdPrefix(request.prefix)
+        completions = @getPropertyNameCompletions(request)
           .concat(@getTagCompletions(request))
       else if not isSass and @isCompletingName(request)
         completions = @getPropertyNameCompletions(request)
@@ -147,6 +147,10 @@ module.exports =
   isPropertyValuePrefix: (prefix) ->
     prefix = prefix.trim()
     prefix.length > 0 and prefix isnt ':'
+
+  isEmptyClassOrIdPrefix: (prefix) ->
+    prefix = prefix.trim()
+    prefix.length > 0 and (prefix is '.' or prefix is '#')
 
   getImportantPrefix: (editor, bufferPosition) ->
     line = editor.getTextInRange([[bufferPosition.row, 0], bufferPosition])

--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -27,7 +27,8 @@ module.exports =
     else if @isCompletingPseudoSelector(request)
       completions = @getPseudoSelectorCompletions(request)
     else
-      if isSass and @isCompletingNameOrTag(request) and not @isEmptyClassOrIdPrefix(request.prefix)
+      {prefix} = request
+      if isSass and @isCompletingNameOrTag(request) and not @isEmptyClassOrIdPrefix(prefix) and not @isCommaPrefix(prefix)
         completions = @getPropertyNameCompletions(request)
           .concat(@getTagCompletions(request))
       else if not isSass and @isCompletingName(request)
@@ -151,6 +152,10 @@ module.exports =
   isEmptyClassOrIdPrefix: (prefix) ->
     prefix = prefix.trim()
     prefix.length > 0 and (prefix is '.' or prefix is '#')
+
+  isCommaPrefix: (prefix) ->
+    prefix = prefix.trim()
+    prefix.length > 0 and prefix is ','
 
   getImportantPrefix: (editor, bufferPosition) ->
     line = editor.getTextInRange([[bufferPosition.row, 0], bufferPosition])

--- a/spec/provider-spec.coffee
+++ b/spec/provider-spec.coffee
@@ -685,6 +685,15 @@ describe "CSS property name and value autocompletions", ->
       completions = getCompletions(activatedManually: false)
       expect(completions).toBe null
 
+    it "does not autocomplete when indented and prefix is a comma", ->
+      editor.setText """
+        body
+          .foo,
+      """
+      editor.setCursorBufferPosition([1, 7])
+      completions = getCompletions(activatedManually: false)
+      expect(completions).toBe null
+
     it "does not autocomplete !important in property-name scope", ->
       editor.setText """
         body {

--- a/spec/provider-spec.coffee
+++ b/spec/provider-spec.coffee
@@ -668,6 +668,23 @@ describe "CSS property name and value autocompletions", ->
 
       expect(important.displayText).toBe '!important'
 
+    it "does not autocomplete when indented and prefix is a dot or a hash", ->
+      editor.setText """
+        body
+          .
+      """
+      editor.setCursorBufferPosition([1, 3])
+      completions = getCompletions(activatedManually: false)
+      expect(completions).toBe null
+
+      editor.setText """
+        body
+          #
+      """
+      editor.setCursorBufferPosition([1, 3])
+      completions = getCompletions(activatedManually: false)
+      expect(completions).toBe null
+
     it "does not autocomplete !important in property-name scope", ->
       editor.setText """
         body {

--- a/spec/provider-spec.coffee
+++ b/spec/provider-spec.coffee
@@ -668,7 +668,7 @@ describe "CSS property name and value autocompletions", ->
 
       expect(important.displayText).toBe '!important'
 
-    it "does not autocomplete when indented and prefix is a dot or a hash", ->
+    it "does not autocomplete when indented and prefix is not a char", ->
       editor.setText """
         body
           .
@@ -685,11 +685,24 @@ describe "CSS property name and value autocompletions", ->
       completions = getCompletions(activatedManually: false)
       expect(completions).toBe null
 
-    it "does not autocomplete when indented and prefix is a comma", ->
       editor.setText """
         body
           .foo,
       """
+      editor.setCursorBufferPosition([1, 7])
+      completions = getCompletions(activatedManually: false)
+      expect(completions).toBe null
+
+      editor.setText """
+        body
+          foo -
+      """
+      editor.setCursorBufferPosition([1, 8])
+      completions = getCompletions(activatedManually: false)
+      expect(completions).toBe null
+
+      # As spaces at end of line will be removed, we'll test with a char
+      # after the space and with the cursor before that char.
       editor.setCursorBufferPosition([1, 7])
       completions = getCompletions(activatedManually: false)
       expect(completions).toBe null


### PR DESCRIPTION
1. Open a sass file
2. Starts writing a class selector by typing a `.` or an id selector by typing a `#`

**Atom Version**: 1.0.4-54f6ed8
**System**: Mac OS X 10.10.4
**Thrown From**: [autocomplete-css](https://github.com/atom/autocomplete-css) package, v0.10.0
### Stack Trace

Uncaught TypeError: Cannot read property 'concat' of null

```
At /Applications/Atom.app/Contents/Resources/app.asar/node_modules/autocomplete-css/lib/provider.js:35

TypeError: Cannot read property 'concat' of null
    at Object.module.exports.getSuggestions (/Applications/Atom.app/Contents/Resources/app.asar/node_modules/autocomplete-css/lib/provider.js:35:79)
    at /Applications/Atom.app/Contents/Resources/app.asar/node_modules/autocomplete-plus/lib/autocomplete-manager.js:267:56
    at Array.forEach (native)
    at AutocompleteManager.module.exports.AutocompleteManager.getSuggestionsFromProviders (/Applications/Atom.app/Contents/Resources/app.asar/node_modules/autocomplete-plus/lib/autocomplete-manager.js:246:17)
    at AutocompleteManager.getSuggestionsFromProviders (/Applications/Atom.app/Contents/Resources/app.asar/node_modules/autocomplete-plus/lib/autocomplete-manager.js:3:61)
    at AutocompleteManager.module.exports.AutocompleteManager.findSuggestions (/Applications/Atom.app/Contents/Resources/app.asar/node_modules/autocomplete-plus/lib/autocomplete-manager.js:233:19)
    at /Applications/Atom.app/Contents/Resources/app.asar/node_modules/autocomplete-plus/lib/autocomplete-manager.js:3:61
```
### Commands

```
     -1:15.3.0 find-and-replace:select-next (atom-text-editor.editor.is-focused)
  2x -1:14.7.0 core:backspace (atom-text-editor.editor.is-focused)
     -1:12.8.0 editor:consolidate-selections (atom-text-editor.editor.is-focused)
     -1:12.4.0 core:save (atom-text-editor.editor.is-focused)
     -0:47.2.0 fuzzy-finder:toggle-file-finder (atom-text-editor.editor.is-focused)
     -0:45.4.0 core:confirm (atom-text-editor.editor.mini.is-focused)
     -0:37.1.0 editor:newline (atom-text-editor.editor.is-focused)
     -0:31.7.0 editor:move-to-beginning-of-word (atom-text-editor.editor.is-focused.autocomplete-active)
     -0:31.3.0 core:move-left (atom-text-editor.editor.is-focused)
     -0:29.1.0 editor:move-to-end-of-screen-line (atom-text-editor.editor.is-focused)
     -0:26.6.0 core:save (atom-text-editor.editor.is-focused)
     -0:25.8.0 editor:newline (atom-text-editor.editor.is-focused)
     -0:25.6.0 snippets:next-tab-stop (atom-text-editor.editor.is-focused)
     -0:25.6.0 snippets:expand (atom-text-editor.editor.is-focused)
     -0:25.6.0 editor:indent (atom-text-editor.editor.is-focused)
     -0:25.2.0 core:save (atom-text-editor.editor.is-focused)
```
### Config

``` json
{
  "core": {
    "disabledPackages": [
      "coffee-lint",
      "emmet",
      "notebook",
      "rsense",
      "font-viewer",
      "react-minimap",
      "sample-minimap-plugin",
      "term2",
      "color-picker",
      "crosshairs",
      "enhanced-package-list",
      "themed-settings",
      "project-palette-finder",
      "atom-color-highlight",
      "view-tail-large-files",
      "minimap-color-highlight",
      "to-base64"
    ],
    "themes": [
      "one-dark-ui",
      "spacegray-dark-syntax"
    ],
    "destroyEmptyPanes": false
  }
}
```
### Installed Packages

``` coffee
# User
Stylus, v1.0.0
about, v1.0.1
bezier-curve-editor, v0.7.2
block-travel, v1.0.2
bug-report, v0.7.1
figlet, v0.4.0
file-icons, v1.5.8
highlight-selected, v0.10.1
language-generic-config, v0.2.0
language-haml, v0.21.0
language-jade, v0.6.2
language-sass, v0.40.0
minimap, v4.12.1
minimap-bookmarks, v0.1.0
minimap-find-and-replace, v4.2.0
minimap-git-diff, v4.1.7
minimap-highlight-selected, v4.3.0
minimap-pigments, v0.1.2
minimap-selection, v4.3.0
php-twig, v4.0.0
pigments, v0.9.2
project-manager, v1.15.11
red-wavy-underline, v0.3.0
spacegray-dark-syntax, v0.2.0
tabs-to-spaces, v0.11.0
travis-ci-status, v0.16.0
tree-view-breadcrumb, v0.6.1
tree-view-open-files, v0.2.4
typewriter, v0.3.3
white-cursor, v0.6.0
zentabs, v0.8.4

# Dev
minimap, v4.12.1
pigments, v0.9.1
```
