### PR TITLE
Fix errors raised in nth-child selector

### DIFF
--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -105,8 +105,9 @@ module.exports =
     else
       true
 
-  isCompletingNameOrTag: ({scopeDescriptor, prefix}) ->
+  isCompletingNameOrTag: ({scopeDescriptor, bufferPosition, editor}) ->
     scopes = scopeDescriptor.getScopesArray()
+    prefix = @getPropertyNamePrefix(bufferPosition, editor)
     return @isPropertyNamePrefix(prefix) and
       hasScope(scopes, 'meta.selector.css') and
       not hasScope(scopes, 'entity.other.attribute-name.id.css.sass') and
@@ -150,8 +151,9 @@ module.exports =
     prefix.length > 0 and prefix isnt ':'
 
   isPropertyNamePrefix: (prefix) ->
+    return false unless prefix?
     prefix = prefix.trim()
-    prefix.length > 0 and prefix.match(/\w/)
+    prefix.length > 0 and prefix.match(/^[a-zA-Z-]+$/)
 
   getImportantPrefix: (editor, bufferPosition) ->
     line = editor.getTextInRange([[bufferPosition.row, 0], bufferPosition])

--- a/spec/provider-spec.coffee
+++ b/spec/provider-spec.coffee
@@ -707,6 +707,32 @@ describe "CSS property name and value autocompletions", ->
       completions = getCompletions(activatedManually: false)
       expect(completions).toBe null
 
+    it 'does not autocomplete when inside a nth-child selector', ->
+      editor.setText """
+        body
+          &:nth-child(4
+      """
+      editor.setCursorBufferPosition([1, 15])
+      completions = getCompletions(activatedManually: false)
+      expect(completions).toBe null
+
+    it 'autocompletes a property name with a dash', ->
+      editor.setText """
+        body
+          border-
+      """
+      editor.setCursorBufferPosition([1, 9])
+      completions = getCompletions(activatedManually: false)
+      expect(completions).not.toBe null
+
+      expect(completions[0].text).toBe 'border: '
+      expect(completions[0].displayText).toBe 'border'
+      expect(completions[0].replacementPrefix).toBe 'border-'
+
+      expect(completions[1].text).toBe 'border-radius: '
+      expect(completions[1].displayText).toBe 'border-radius'
+      expect(completions[1].replacementPrefix).toBe 'border-'
+
     it "does not autocomplete !important in property-name scope", ->
       editor.setText """
         body {


### PR DESCRIPTION
I missed some cases in my previous PR for #27: 
The `:nth-child` argument was caught by the `isPropertyNamePrefix` method leading to another uncaught exception. And at the same time it was preventing property names to be completed
when triggered after a `-` (like in `border-`).
