### PR TITLE
Swap order of background-image: url() and image()

### DIFF
--- a/completions.json
+++ b/completions.json
@@ -326,12 +326,12 @@
     },
     "background-image": {
       "values": [
-        "image()",
+        "url()",
         "linear-gradient()",
         "radial-gradient()",
         "repeating-linear-gradient()",
         "repeating-radial-gradient()",
-        "url()"
+        "image()"
       ],
       "description": "Sets one or several background images for an element."
     },


### PR DESCRIPTION
This is for convenience, I think url() is used significantly more and
therefore should be at the top. While image() is used almost never
