### PR TITLE
selector and disableForSelector as configuration settings

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -1,6 +1,14 @@
 provider = require './provider'
 
 module.exports =
+  config:
+    selector:
+      type: 'string'
+      default: '.source.css, .source.sass'
+    disableForSelector:
+      type: 'string'
+      default: '.source.css .comment, .source.css .string, .source.sass .comment, .source.sass .string'
+
   activate: -> provider.loadProperties()
 
   getProvider: -> provider

--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -9,8 +9,8 @@ importantPrefixPattern = /(![a-z]+)$/
 cssDocsURL = "https://developer.mozilla.org/en-US/docs/Web/CSS"
 
 module.exports =
-  selector: '.source.css, .source.sass'
-  disableForSelector: '.source.css .comment, .source.css .string, .source.sass .comment, .source.sass .string'
+  selector: atom.config.get('autocomplete-css.selector')
+  disableForSelector: atom.config.get('autocomplete-css.disableForSelector')
 
   # Tell autocomplete to fuzzy filter the results of getSuggestions(). We are
   # still filtering by the first character of the prefix in this provider for


### PR DESCRIPTION
This allows for other "languages" to use the CSS autocomplete-css package without forking it.  The primary reason why this PR is useful is for (https://github.com/rtsao/csjs and by proxy https://github.com/neurosnap/language-csjs).

Please let me know if there's a better way to customize this package, this seemed like that path of least resistance.
