### PR TITLE
Update specs based on language-css changes

### DIFF
--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -60,7 +60,8 @@ module.exports =
     previousScopes = editor.scopeDescriptorForBufferPosition(previousBufferPosition)
     previousScopesArray = previousScopes.getScopesArray()
 
-    (hasScope(scopes, 'meta.property-value.css') and not hasScope(scopes, 'punctuation.separator.key-value.css')) or
+    (hasScope(scopes, 'meta.property-list.css') and prefix.trim() is ":") or
+    (hasScope(scopes, 'meta.property-value.css')) or
     (hasScope(scopes, 'meta.property-list.scss') and prefix.trim() is ":") or
     (hasScope(scopes, 'meta.property-value.scss')) or
     (hasScope(scopes, 'source.sass') and (hasScope(scopes, 'meta.property-value.sass') or


### PR DESCRIPTION
These changes make the specs pass again on language-css versions 0.40.0 and up.

This build will fail as language-css is still 0.39.0 on stable, **and** because language-less shares the same tokens as language-css but hasn't been updated yet.  So what I'm going to do is effectively the same as what I did last time:
1. Wait for atom/language-less#61 to be merged, and a new version to be published.
2. Merge this PR, despite the :rotating_light: status.
3. Publish a new version.
4. Comment out the offending specs with a reminder to re-enable them come Atom 1.12.0.
