### PR TITLE
Fix inline property-value completion

### DIFF
--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -69,7 +69,7 @@ module.exports =
     (hasScope(scopes, 'meta.property-list.css') and prefix.trim() is ":") or
     (hasScope(previousScopesArray, 'meta.property-value.css')) or
     (hasScope(scopes, 'meta.property-list.scss') and prefix.trim() is ":") or
-    (hasScope(scopes, 'meta.property-value.scss')) or
+    (hasScope(previousScopesArray, 'meta.property-value.scss')) or
     (hasScope(scopes, 'source.sass') and (hasScope(scopes, 'meta.property-value.sass') or
       (not hasScope(beforePrefixScopesArray, "entity.name.tag.css.sass") and prefix.trim() is ":")
     ))

--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -1,7 +1,9 @@
 fs = require 'fs'
 path = require 'path'
 
-propertyNameWithColonPattern = /^\s*(\S+)\s*:/
+firstInlinePropertyNameWithColonPattern = /{\s*(\S+)\s*:/ # .example { display: }
+inlinePropertyNameWithColonPattern = /(?:;.+?)*;\s*(\S+)\s*:/ # .example { display: block; float: left; color: } (match the last one)
+propertyNameWithColonPattern = /^\s*(\S+)\s*:/ # display:
 propertyNamePrefixPattern = /[a-zA-Z]+[-a-zA-Z]*$/
 pesudoSelectorPrefixPattern = /:(:)?([a-z]+[a-z-]*)?$/
 tagSelectorPrefixPattern = /(^|\s|,)([a-z]+)?$/
@@ -165,6 +167,8 @@ module.exports =
     while row >= 0
       line = editor.lineTextForBufferRow(row)
       propertyName = propertyNameWithColonPattern.exec(line)?[1]
+      propertyName ?= inlinePropertyNameWithColonPattern.exec(line)?[1]
+      propertyName ?= firstInlinePropertyNameWithColonPattern.exec(line)?[1]
       return propertyName if propertyName
       row--
     return

--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -66,7 +66,6 @@ module.exports =
     previousScopes = editor.scopeDescriptorForBufferPosition(previousBufferPosition)
     previousScopesArray = previousScopes.getScopesArray()
 
-
     (hasScope(scopes, 'meta.property-list.css') and prefix.trim() is ":") or
     (hasScope(previousScopesArray, 'meta.property-value.css')) or
     (hasScope(scopes, 'meta.property-list.scss') and prefix.trim() is ":") or

--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -125,12 +125,16 @@ module.exports =
     tagSelectorPrefix = @getTagSelectorPrefix(editor, bufferPosition)
     return false unless tagSelectorPrefix?.length
 
+    previousBufferPosition = [bufferPosition.row, Math.max(0, bufferPosition.column - 1)]
+    previousScopes = editor.scopeDescriptorForBufferPosition(previousBufferPosition)
+    previousScopesArray = previousScopes.getScopesArray()
+
     if hasScope(scopes, 'meta.selector.css')
       true
     else if hasScope(scopes, 'source.css.scss') or hasScope(scopes, 'source.css.less')
-      not hasScope(scopes, 'meta.property-value.scss') and
-        not hasScope(scopes, 'meta.property-value.css') and
-        not hasScope(scopes, 'support.type.property-value.css')
+      not hasScope(previousScopesArray, 'meta.property-value.scss') and
+        not hasScope(previousScopesArray, 'meta.property-value.css') and
+        not hasScope(previousScopesArray, 'support.type.property-value.css')
     else
       false
 

--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -58,16 +58,21 @@ module.exports =
   isCompletingValue: ({scopeDescriptor, bufferPosition, prefix, editor}) ->
     scopes = scopeDescriptor.getScopesArray()
 
-    previousBufferPosition = [bufferPosition.row, Math.max(0, bufferPosition.column - prefix.length - 1)]
+    beforePrefixBufferPosition = [bufferPosition.row, Math.max(0, bufferPosition.column - prefix.length - 1)]
+    beforePrefixScopes = editor.scopeDescriptorForBufferPosition(beforePrefixBufferPosition)
+    beforePrefixScopesArray = beforePrefixScopes.getScopesArray()
+
+    previousBufferPosition = [bufferPosition.row, Math.max(0, bufferPosition.column - 1)]
     previousScopes = editor.scopeDescriptorForBufferPosition(previousBufferPosition)
     previousScopesArray = previousScopes.getScopesArray()
 
+
     (hasScope(scopes, 'meta.property-list.css') and prefix.trim() is ":") or
-    (hasScope(scopes, 'meta.property-value.css')) or
+    (hasScope(previousScopesArray, 'meta.property-value.css')) or
     (hasScope(scopes, 'meta.property-list.scss') and prefix.trim() is ":") or
     (hasScope(scopes, 'meta.property-value.scss')) or
     (hasScope(scopes, 'source.sass') and (hasScope(scopes, 'meta.property-value.sass') or
-      (not hasScope(previousScopesArray, "entity.name.tag.css.sass") and prefix.trim() is ":")
+      (not hasScope(beforePrefixScopesArray, "entity.name.tag.css.sass") and prefix.trim() is ":")
     ))
 
   isCompletingName: ({scopeDescriptor, bufferPosition, prefix, editor}) ->

--- a/spec/provider-spec.coffee
+++ b/spec/provider-spec.coffee
@@ -323,6 +323,26 @@ describe "CSS property name and value autocompletions", ->
         expect(completions).toHaveLength 1
         expect(completions[0].text).toBe 'center;'
 
+      it "autocompletes inline property values", ->
+        editor.setText "body { display: }"
+        editor.setCursorBufferPosition([0, 16])
+        completions = getCompletions()
+        expect(completions).toHaveLength 21
+        expect(completions[0].text).toBe 'block;'
+
+      it "autocompletes more than one inline property value", ->
+        editor.setText "body { display: block; float: }"
+        editor.setCursorBufferPosition([0, 30])
+        completions = getCompletions()
+        expect(completions).toHaveLength 4
+        expect(completions[0].text).toBe 'left;'
+
+        editor.setText "body { display: block; float: left; cursor: alias; text-decoration: }"
+        editor.setCursorBufferPosition([0, 68])
+        completions = getCompletions()
+        expect(completions).toHaveLength 5
+        expect(completions[0].text).toBe 'line-through;'
+
       it "autocompletes !important in property-value scope", ->
         editor.setText """
           body {

--- a/spec/provider-spec.coffee
+++ b/spec/provider-spec.coffee
@@ -343,6 +343,29 @@ describe "CSS property name and value autocompletions", ->
         expect(completions).toHaveLength 5
         expect(completions[0].text).toBe 'line-through;'
 
+      it "autocompletes inline property values with a prefix", ->
+        editor.setText "body { display: i }"
+        editor.setCursorBufferPosition([0, 17])
+        completions = getCompletions()
+        expect(completions).toHaveLength 6
+        expect(completions[0].text).toBe 'inline;'
+        expect(completions[1].text).toBe 'inline-block;'
+        expect(completions[2].text).toBe 'inline-flex;'
+        expect(completions[3].text).toBe 'inline-grid;'
+        expect(completions[4].text).toBe 'inline-table;'
+        expect(completions[5].text).toBe 'inherit;'
+
+        editor.setText "body { display: i}"
+        editor.setCursorBufferPosition([0, 17])
+        completions = getCompletions()
+        expect(completions).toHaveLength 6
+        expect(completions[0].text).toBe 'inline;'
+        expect(completions[1].text).toBe 'inline-block;'
+        expect(completions[2].text).toBe 'inline-flex;'
+        expect(completions[3].text).toBe 'inline-grid;'
+        expect(completions[4].text).toBe 'inline-table;'
+        expect(completions[5].text).toBe 'inherit;'
+
       it "autocompletes !important in property-value scope", ->
         editor.setText """
           body {


### PR DESCRIPTION
The regex being used to look for the property name didn't take inline property lists into account.

Fixes #31

/cc @benogle
