### PR TITLE
Fix specs for language-css changes

### DIFF
--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -98,10 +98,10 @@ module.exports =
 
     isAtBeginScopePunctuation = hasScope(scopes, 'punctuation.section.property-list.begin.bracket.curly.css') or
       hasScope(scopes, 'punctuation.section.property-list.begin.bracket.curly.scss') or
-      hasScope(scopes, 'punctuation.section.property-list.css') # TODO: Remove in Atom 1.15
+      hasScope(scopes, 'punctuation.section.property-list.begin.css') # TODO: Remove in Atom 1.15
     isAtEndScopePunctuation = hasScope(scopes, 'punctuation.section.property-list.end.bracket.curly.css') or
       hasScope(scopes, 'punctuation.section.property-list.end.bracket.curly.scss') or
-      hasScope(scopes, 'punctuation.section.property-list.css') # TODO: Remove in Atom 1.15
+      hasScope(scopes, 'punctuation.section.property-list.end.css') # TODO: Remove in Atom 1.15
 
     if isAtBeginScopePunctuation
       # * Disallow here: `canvas,|{}`

--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -96,9 +96,9 @@ module.exports =
       hasScope(previousScopesArray, 'entity.name.tag.reference.scss') or
       hasScope(previousScopesArray, 'entity.name.tag.scss')
 
-    isAtBeginScopePunctuation = hasScope(scopes, 'punctuation.section.property-list.begin.css') or
+    isAtBeginScopePunctuation = hasScope(scopes, 'punctuation.section.property-list.begin.bracket.curly.css') or
       hasScope(scopes, 'punctuation.section.property-list.begin.bracket.curly.scss')
-    isAtEndScopePunctuation = hasScope(scopes, 'punctuation.section.property-list.end.css') or
+    isAtEndScopePunctuation = hasScope(scopes, 'punctuation.section.property-list.end.bracket.curly.css') or
       hasScope(scopes, 'punctuation.section.property-list.end.bracket.curly.scss')
 
     if isAtBeginScopePunctuation
@@ -129,7 +129,7 @@ module.exports =
     previousScopes = editor.scopeDescriptorForBufferPosition(previousBufferPosition)
     previousScopesArray = previousScopes.getScopesArray()
 
-    if hasScope(scopes, 'meta.selector.css')
+    if hasScope(scopes, 'meta.selector.css') or hasScope(previousScopesArray, 'meta.selector.css')
       true
     else if hasScope(scopes, 'source.css.scss') or hasScope(scopes, 'source.css.less')
       not hasScope(previousScopesArray, 'meta.property-value.scss') and
@@ -140,7 +140,10 @@ module.exports =
 
   isCompletingPseudoSelector: ({editor, scopeDescriptor, bufferPosition}) ->
     scopes = scopeDescriptor.getScopesArray()
-    if hasScope(scopes, 'meta.selector.css') and not hasScope(scopes, 'source.sass')
+    previousBufferPosition = [bufferPosition.row, Math.max(0, bufferPosition.column - 1)]
+    previousScopes = editor.scopeDescriptorForBufferPosition(previousBufferPosition)
+    previousScopesArray = previousScopes.getScopesArray()
+    if (hasScope(scopes, 'meta.selector.css') or hasScope(previousScopesArray, 'meta.selector.css')) and not hasScope(scopes, 'source.sass')
       true
     else if hasScope(scopes, 'source.css.scss') or hasScope(scopes, 'source.css.less') or hasScope(scopes, 'source.sass')
       prefix = @getPseudoSelectorPrefix(editor, bufferPosition)

--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -97,9 +97,11 @@ module.exports =
       hasScope(previousScopesArray, 'entity.name.tag.scss')
 
     isAtBeginScopePunctuation = hasScope(scopes, 'punctuation.section.property-list.begin.bracket.curly.css') or
-      hasScope(scopes, 'punctuation.section.property-list.begin.bracket.curly.scss')
+      hasScope(scopes, 'punctuation.section.property-list.begin.bracket.curly.scss') or
+      hasScope(scopes, 'punctuation.section.property-list.css') # TODO: Remove in Atom 1.15
     isAtEndScopePunctuation = hasScope(scopes, 'punctuation.section.property-list.end.bracket.curly.css') or
-      hasScope(scopes, 'punctuation.section.property-list.end.bracket.curly.scss')
+      hasScope(scopes, 'punctuation.section.property-list.end.bracket.curly.scss') or
+      hasScope(scopes, 'punctuation.section.property-list.css') # TODO: Remove in Atom 1.15
 
     if isAtBeginScopePunctuation
       # * Disallow here: `canvas,|{}`


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Just keeping specs passing.  This PR will likely result in _a lot_ of temporarily disabled specs after I see which ones fail on stable.

### Alternate Designs

I can keep the specs undisabled, but that means lots of failures on autocomplete-css master.
EDIT: I actually went for backwards-compat instead.  That seems like a better choice this time around.

### Benefits

Continued autocompletion for CSS.

### Possible Drawbacks

Should be none.

### Applicable Issues

None.