### PR TITLE
Change provider to add no semicolon if one is already present

### DIFF
--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -192,14 +192,15 @@ module.exports =
     return null unless values?
 
     scopes = scopeDescriptor.getScopesArray()
+    addSemicolon = not lineEndsWithSemicolon(bufferPosition, editor) and not hasScope(scopes, 'source.sass')
 
     completions = []
     if @isPropertyValuePrefix(prefix)
       for value in values when firstCharsEqual(value, prefix)
-        completions.push(@buildPropertyValueCompletion(value, property, scopes))
+        completions.push(@buildPropertyValueCompletion(value, property, addSemicolon))
     else
       for value in values
-        completions.push(@buildPropertyValueCompletion(value, property, scopes))
+        completions.push(@buildPropertyValueCompletion(value, property, addSemicolon))
 
     if importantPrefix = @getImportantPrefix(editor, bufferPosition)
       # attention: règle dangereux
@@ -213,9 +214,9 @@ module.exports =
 
     completions
 
-  buildPropertyValueCompletion: (value, propertyName, scopes) ->
+  buildPropertyValueCompletion: (value, propertyName, addSemicolon) ->
     text = value
-    text += ';' unless hasScope(scopes, 'source.sass')
+    text += ';' if addSemicolon
 
     {
       type: 'value'
@@ -292,6 +293,11 @@ module.exports =
     type: 'tag'
     text: tag
     description: "Selector for <#{tag}> elements"
+
+lineEndsWithSemicolon = (bufferPosition, editor) ->
+  {row} = bufferPosition
+  line = editor.lineTextForBufferRow(row)
+  /;\s*$/.test(line)
 
 hasScope = (scopesArray, scope) ->
   scopesArray.indexOf(scope) isnt -1

--- a/spec/provider-spec.coffee
+++ b/spec/provider-spec.coffee
@@ -322,6 +322,17 @@ describe "CSS property name and value autocompletions", ->
         expect(completions).toHaveLength 1
         expect(completions[0].text).toBe 'center;'
 
+      it "it doesn't add semicolon after a property if one is already present", ->
+        editor.setText """
+          body {
+            display: i;
+          }
+        """
+        editor.setCursorBufferPosition([1, 12])
+        completions = getCompletions()
+        completions.forEach (completion) ->
+          expect(completion.text).not.toMatch(/;\s*$/)
+
       it "autocompletes inline property values", ->
         editor.setText "body { display: }"
         editor.setCursorBufferPosition([0, 16])


### PR DESCRIPTION
### Description of the Change

This PR will change the CSS autocomplete provider to add no semicolons after a CSS property if one is already present.
### Example:
In this code
```css
body {
  display: i;
}
```
Pressing <kbd>ctrl-shift-space</kbd> after `display: i` and choosing `inline-block` previously added another semicolon and therefore resulted in something like this:
```css
body {
  display: inline-block;;
}
```
### Alternate Designs
None
### Benefits
Improves UX
### Possible Drawbacks
Unknown
### Applicable Issues
None