### PR TITLE
Added PostCSS Support [fixes #37]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: objective-c
 
+env:
+  global:
+    - APM_TEST_PACKAGES="language-postcss"
+
 notifications:
   email:
     on_success: never

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 ### Project specific config ###
 environment:
-  APM_TEST_PACKAGES:
+  APM_TEST_PACKAGES: "language-postcss"
   ATOM_LINT_WITH_BUNDLED_NODE: "true"
 
   matrix:

--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -78,13 +78,16 @@ module.exports =
     scopes = scopeDescriptor.getScopesArray()
     isAtTerminator = prefix.endsWith(';')
     isAtParentSymbol = prefix.endsWith('&')
+    isVariable = hasScope(scopes, 'variable.css') or
+      hasScope(scopes, 'variable.scss') or
+      hasScope(scopes, 'variable.var.postcss')
     isInPropertyList = not isAtTerminator and
       (hasScope(scopes, 'meta.property-list.css') or
       hasScope(scopes, 'meta.property-list.scss') or
       hasScope(scopes, 'meta.property-list.postcss'))
 
     return false unless isInPropertyList
-    return false if isAtParentSymbol
+    return false if isAtParentSymbol or isVariable
 
     previousBufferPosition = [bufferPosition.row, Math.max(0, bufferPosition.column - prefix.length - 1)]
     previousScopes = editor.scopeDescriptorForBufferPosition(previousBufferPosition)

--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -12,8 +12,8 @@ importantPrefixPattern = /(![a-z]+)$/
 cssDocsURL = "https://developer.mozilla.org/en-US/docs/Web/CSS"
 
 module.exports =
-  selector: '.source.css, .source.sass'
-  disableForSelector: '.source.css .comment, .source.css .string, .source.sass .comment, .source.sass .string'
+  selector: '.source.css, .source.sass, .source.css.postcss'
+  disableForSelector: '.source.css .comment, .source.css .string, .source.sass .comment, .source.sass .string, .source.css.postcss .comment, source.css.postcss .string'
   properties: COMPLETIONS.properties
   pseudoSelectors: COMPLETIONS.pseudoSelectors
   tags: COMPLETIONS.tags
@@ -68,6 +68,8 @@ module.exports =
     (hasScope(previousScopesArray, 'meta.property-value.css')) or
     (hasScope(scopes, 'meta.property-list.scss') and prefix.trim() is ":") or
     (hasScope(previousScopesArray, 'meta.property-value.scss')) or
+    (hasScope(scopes, 'meta.property-list.postcss') and prefix.trim() is ":") or
+    (hasScope(previousScopesArray, 'meta.property-value.postcss')) or
     (hasScope(scopes, 'source.sass', true) and (hasScope(scopes, 'meta.property-value.sass') or
       (not hasScope(beforePrefixScopesArray, 'entity.name.tag.css') and prefix.trim() is ":")
     ))
@@ -78,7 +80,8 @@ module.exports =
     isAtParentSymbol = prefix.endsWith('&')
     isInPropertyList = not isAtTerminator and
       (hasScope(scopes, 'meta.property-list.css') or
-      hasScope(scopes, 'meta.property-list.scss'))
+      hasScope(scopes, 'meta.property-list.scss') or
+      hasScope(scopes, 'meta.property-list.postcss'))
 
     return false unless isInPropertyList
     return false if isAtParentSymbol
@@ -92,12 +95,16 @@ module.exports =
       hasScope(previousScopesArray, 'entity.other.attribute-name.id') or
       hasScope(previousScopesArray, 'entity.other.attribute-name.parent-selector.css') or
       hasScope(previousScopesArray, 'entity.name.tag.reference.scss') or
-      hasScope(previousScopesArray, 'entity.name.tag.scss')
+      hasScope(previousScopesArray, 'entity.name.tag.scss') or
+      hasScope(previousScopesArray, 'entity.name.tag.reference.postcss') or
+      hasScope(previousScopesArray, 'entity.name.tag.postcss')
 
     isAtBeginScopePunctuation = hasScope(scopes, 'punctuation.section.property-list.begin.bracket.curly.css') or
-      hasScope(scopes, 'punctuation.section.property-list.begin.bracket.curly.scss')
+      hasScope(scopes, 'punctuation.section.property-list.begin.bracket.curly.scss') or
+      hasScope(scopes, 'punctuation.section.property-list.begin.postcss')
     isAtEndScopePunctuation = hasScope(scopes, 'punctuation.section.property-list.end.bracket.curly.css') or
-      hasScope(scopes, 'punctuation.section.property-list.end.bracket.curly.scss')
+      hasScope(scopes, 'punctuation.section.property-list.end.bracket.curly.scss') or
+      hasScope(scopes, 'punctuation.section.property-list.end.postcss')
 
     if isAtBeginScopePunctuation
       # * Disallow here: `canvas,|{}`
@@ -129,9 +136,10 @@ module.exports =
 
     if hasScope(scopes, 'meta.selector.css') or hasScope(previousScopesArray, 'meta.selector.css')
       true
-    else if hasScope(scopes, 'source.css.scss', true) or hasScope(scopes, 'source.css.less', true)
+    else if hasScope(scopes, 'source.css.scss', true) or hasScope(scopes, 'source.css.less', true) or hasScope(scopes, 'source.css.postcss', true)
       not hasScope(previousScopesArray, 'meta.property-value.scss') and
         not hasScope(previousScopesArray, 'meta.property-value.css') and
+        not hasScope(previousScopesArray, 'meta.property-value.postcss') and
         not hasScope(previousScopesArray, 'support.type.property-value.css')
     else
       false
@@ -143,7 +151,7 @@ module.exports =
     previousScopesArray = previousScopes.getScopesArray()
     if (hasScope(scopes, 'meta.selector.css') or hasScope(previousScopesArray, 'meta.selector.css')) and not hasScope(scopes, 'source.sass', true)
       true
-    else if hasScope(scopes, 'source.css.scss', true) or hasScope(scopes, 'source.css.less', true) or hasScope(scopes, 'source.sass', true)
+    else if hasScope(scopes, 'source.css.scss', true) or hasScope(scopes, 'source.css.less', true) or hasScope(scopes, 'source.sass', true) or hasScope(scopes, 'source.css.postcss', true)
       prefix = @getPseudoSelectorPrefix(editor, bufferPosition)
       if prefix
         previousBufferPosition = [bufferPosition.row, Math.max(0, bufferPosition.column - prefix.length - 1)]
@@ -151,8 +159,10 @@ module.exports =
         previousScopesArray = previousScopes.getScopesArray()
         not hasScope(previousScopesArray, 'meta.property-name.scss') and
           not hasScope(previousScopesArray, 'meta.property-value.scss') and
+          not hasScope(previousScopesArray, 'meta.property-value.postcss') and
           not hasScope(previousScopesArray, 'support.type.property-name.css') and
-          not hasScope(previousScopesArray, 'support.type.property-value.css')
+          not hasScope(previousScopesArray, 'support.type.property-value.css') and
+          not hasScope(previousScopesArray, 'support.type.property-name.postcss')
       else
         false
     else

--- a/spec/provider-spec.coffee
+++ b/spec/provider-spec.coffee
@@ -8,6 +8,9 @@ packagesToTest =
   Less:
     name: 'language-less'
     file: 'test.less'
+  PostCSS:
+    name: 'language-postcss'
+    file: 'test.css'
 
 describe "CSS property name and value autocompletions", ->
   [editor, provider] = []
@@ -548,7 +551,7 @@ describe "CSS property name and value autocompletions", ->
           expect(completions[0].text).toBe ':first'
 
   Object.keys(packagesToTest).forEach (packageLabel) ->
-    if packagesToTest[packageLabel].name in ['language-sass', 'language-less']
+    if packagesToTest[packageLabel].name in ['language-sass', 'language-less', 'language-postcss']
       describe "#{packageLabel} files", ->
         beforeEach ->
           waitsForPromise -> atom.packages.activatePackage(packagesToTest[packageLabel].name)

--- a/spec/provider-spec.coffee
+++ b/spec/provider-spec.coffee
@@ -10,7 +10,7 @@ packagesToTest =
     file: 'test.less'
   PostCSS:
     name: 'language-postcss'
-    file: 'test.css'
+    file: 'test.postcss'
 
 describe "CSS property name and value autocompletions", ->
   [editor, provider] = []


### PR DESCRIPTION
### Requirements

* &#10003; Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* &#10003; All new code requires tests to ensure against regressions

### Description of the Change

I added PostCSS scope checks to provider, in order to enable language-postcss to be autocompleted through this provider.

### Alternate Designs

The alternative could be use language-css while using PostCSS, but the programming experience would be really awful.

### Benefits

Enables language-postcss to be completed trough autocomplete-css provider. Everybody who use postcss can take advantages of both postcss syntax highlight and autocompletition. 
Fixes #37.

### Possible Drawbacks

PostCSS is not a real syntax, but a collection of plugins: it's impossible to anticipate the exact configuration of the user, so the PostCSS support should be improved gradually to cover most of the possible scenarios.

### Applicable Issues

There is room for improvement: a better veriables support, prevents `display: var(--b)` to be autocompleted in `display: var(--block)` (now it's a general problem, the same happens with `display: $b` -> `display: $block`)
