### PR TITLE
Make way for variable completions

### DIFF
--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -24,16 +24,17 @@ module.exports =
     scopes = request.scopeDescriptor.getScopesArray()
     isSass = hasScope(scopes, 'source.sass')
 
-    if @isCompletingValue(request)
-      completions = @getPropertyValueCompletions(request)
-    else if @isCompletingPseudoSelector(request)
-      completions = @getPseudoSelectorCompletions(request)
-    else
-      if isSass and @isCompletingNameOrTag(request)
-        completions = @getPropertyNameCompletions(request)
-          .concat(@getTagCompletions(request))
-      else if not isSass and @isCompletingName(request)
-        completions = @getPropertyNameCompletions(request)
+    if not @isCompletingCustomProperty(request)
+      if @isCompletingValue(request)
+        completions = @getPropertyValueCompletions(request)
+      else if @isCompletingPseudoSelector(request)
+        completions = @getPseudoSelectorCompletions(request)
+      else
+        if isSass and @isCompletingNameOrTag(request)
+          completions = @getPropertyNameCompletions(request)
+            .concat(@getTagCompletions(request))
+        else if not isSass and @isCompletingName(request)
+          completions = @getPropertyNameCompletions(request)
 
     if not isSass and @isCompletingTagSelector(request)
       tagCompletions = @getTagCompletions(request)
@@ -54,6 +55,12 @@ module.exports =
     fs.readFile path.resolve(__dirname, '..', 'completions.json'), (error, content) =>
       {@pseudoSelectors, @properties, @tags} = JSON.parse(content) unless error?
       return
+
+  isCompletingCustomProperty: ({scopeDescriptor}) ->
+    scopes = scopeDescriptor.getScopesArray()
+
+    (hasScope(scopes, 'variable.css')) or
+    (hasScope(scopes, 'meta.function.variable.css'))
 
   isCompletingValue: ({scopeDescriptor, bufferPosition, prefix, editor}) ->
     scopes = scopeDescriptor.getScopesArray()

--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -24,7 +24,7 @@ module.exports =
     scopes = request.scopeDescriptor.getScopesArray()
     isSass = hasScope(scopes, 'source.sass')
 
-    if not @isCompletingCustomProperty(request)
+    unless @isCompletingCustomProperty(request)
       if @isCompletingValue(request)
         completions = @getPropertyValueCompletions(request)
       else if @isCompletingPseudoSelector(request)
@@ -59,8 +59,8 @@ module.exports =
   isCompletingCustomProperty: ({scopeDescriptor}) ->
     scopes = scopeDescriptor.getScopesArray()
 
-    (hasScope(scopes, 'variable.css')) or
-    (hasScope(scopes, 'meta.function.variable.css'))
+    hasScope(scopes, 'variable.css') or
+    hasScope(scopes, 'meta.function.variable.css')
 
   isCompletingValue: ({scopeDescriptor, bufferPosition, prefix, editor}) ->
     scopes = scopeDescriptor.getScopesArray()


### PR DESCRIPTION
### Description of the Change
`getSuggestions` now performs an initial check for scopes indicating custom properties, and only drops into resolving additional suggestions if this is not the case.

### Benefits

This allows tokens resolved as per https://github.com/atom/language-css/pull/102 to be available in the custom property scopes and _no other tokens_ (AFAIK, no other suggestions are applicable here).

### Applicable Issues

https://github.com/atom/autocomplete-css/issues/56
https://github.com/atom/autocomplete-plus/issues/740