### PR TITLE
Autocomplete inline property values that aren't at the end of the line

### DIFF
--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -176,9 +176,10 @@ module.exports =
     importantPrefixPattern.exec(line)?[1]
 
   getPreviousPropertyName: (bufferPosition, editor) ->
-    {row} = bufferPosition
+    {row, column} = bufferPosition
     while row >= 0
       line = editor.lineTextForBufferRow(row)
+      line = line.substr(0, column) if row is bufferPosition.row
       propertyName = inlinePropertyNameWithColonPattern.exec(line)?[1]
       propertyName ?= firstInlinePropertyNameWithColonPattern.exec(line)?[1]
       propertyName ?= propertyNameWithColonPattern.exec(line)?[1]

--- a/spec/provider-spec.coffee
+++ b/spec/provider-spec.coffee
@@ -386,6 +386,16 @@ describe "CSS property name and value autocompletions", ->
         expect(completions[4].text).toBe 'inline-table;'
         expect(completions[5].text).toBe 'inherit;'
 
+      it "autocompletes inline property values that aren't at the end of the line", ->
+        editor.setText "body { float: display: inline; font-weight: bold; }"
+        editor.setCursorBufferPosition([0, 14]) # right before display
+        completions = getCompletions()
+        expect(completions).toHaveLength 4
+        expect(completions[0].text).toBe 'left;'
+        expect(completions[1].text).toBe 'right;'
+        expect(completions[2].text).toBe 'none;'
+        expect(completions[3].text).toBe 'inherit;'
+
       it "autocompletes !important in property-value scope", ->
         editor.setText """
           body {


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Prior to this change, we were matching the entire line to find the previous property name, regardless of where the cursor currently was.  This obviously will not work as expected if there are additional property names past where your cursor is.  So now we take a substring of the line up to the cursor position if it's the row that we started on (otherwise, the entire row should be checked).

### Alternate Designs

None.

### Benefits

If you have multiple property names on a single line, and try to edit/add a property name somewhere in the beginning, you will now get correct property value completions.

### Possible Drawbacks

None.

### Applicable Issues

Fixes #83