### PR TITLE
Update in accordance to latest language-sass changes

### DIFF
--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -71,7 +71,7 @@ module.exports =
     (hasScope(scopes, 'meta.property-list.scss') and prefix.trim() is ":") or
     (hasScope(previousScopesArray, 'meta.property-value.scss')) or
     (hasScope(scopes, 'source.sass') and (hasScope(scopes, 'meta.property-value.sass') or
-      (not hasScope(beforePrefixScopesArray, "entity.name.tag.css.sass") and prefix.trim() is ":")
+      (not hasScope(beforePrefixScopesArray, "entity.name.tag.css") and prefix.trim() is ":")
     ))
 
   isCompletingName: ({scopeDescriptor, bufferPosition, prefix, editor}) ->

--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -71,8 +71,10 @@ module.exports =
     (hasScope(scopes, 'meta.property-list.scss') and prefix.trim() is ":") or
     (hasScope(previousScopesArray, 'meta.property-value.scss')) or
     (hasScope(scopes, 'source.sass') and (hasScope(scopes, 'meta.property-value.sass') or
-      (not hasScope(beforePrefixScopesArray, "entity.name.tag.css") and prefix.trim() is ":")
+      (not hasScope(beforePrefixScopesArray, 'entity.name.tag.css') and
+       not hasScope(beforePrefixScopesArray, 'entity.name.tag.css.sass') and prefix.trim() is ":")
     ))
+    # TODO: ^ Remove entity.name.tag.css.sass in Atom 1.17.0
 
   isCompletingName: ({scopeDescriptor, bufferPosition, prefix, editor}) ->
     scopes = scopeDescriptor.getScopesArray()

--- a/spec/provider-spec.coffee
+++ b/spec/provider-spec.coffee
@@ -27,6 +27,7 @@ describe "CSS property name and value autocompletions", ->
 
   beforeEach ->
     waitsForPromise -> atom.packages.activatePackage('autocomplete-css')
+    waitsForPromise -> atom.packages.activatePackage('language-css') # Used in all CSS languages
 
     runs ->
       provider = atom.packages.getActivePackage('autocomplete-css').mainModule.getProvider()


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Really small change here.  The tag scope is now `entity.name.tag.css` in Sass, without the trailing `.sass`.  language-css is now also included in all the CSS-like grammars, so always activate it.

### Alternate Designs

None.

### Benefits

Ideally, none - everything will continue to function like before.

### Possible Drawbacks

See Benefits.

### Applicable Issues

None.

Depending on if CI passes or not I'll try to make this backwards-compatible.