### PR TITLE
Support reading completions.json when loading the package from snapshot

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -1,6 +1,6 @@
 provider = require './provider'
 
 module.exports =
-  activate: -> provider.loadProperties()
+  activate: ->
 
   getProvider: -> provider

--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -1,5 +1,6 @@
-fs = require 'fs'
 path = require 'path'
+
+COMPLETIONS = require('../completions.json')
 
 firstInlinePropertyNameWithColonPattern = /{\s*(\S+)\s*:/ # .example { display: }
 inlinePropertyNameWithColonPattern = /(?:;.+?)*;\s*(\S+)\s*:/ # .example { display: block; float: left; color: } (match the last one)
@@ -13,6 +14,9 @@ cssDocsURL = "https://developer.mozilla.org/en-US/docs/Web/CSS"
 module.exports =
   selector: '.source.css, .source.sass'
   disableForSelector: '.source.css .comment, .source.css .string, .source.sass .comment, .source.sass .string'
+  properties: COMPLETIONS.properties
+  pseudoSelectors: COMPLETIONS.pseudoSelectors
+  tags: COMPLETIONS.tags
 
   # Tell autocomplete to fuzzy filter the results of getSuggestions(). We are
   # still filtering by the first character of the prefix in this provider for
@@ -48,12 +52,6 @@ module.exports =
 
   triggerAutocomplete: (editor) ->
     atom.commands.dispatch(atom.views.getView(editor), 'autocomplete-plus:activate', {activatedManually: false})
-
-  loadProperties: ->
-    @properties = {}
-    fs.readFile path.resolve(__dirname, '..', 'completions.json'), (error, content) =>
-      {@pseudoSelectors, @properties, @tags} = JSON.parse(content) unless error?
-      return
 
   isCompletingValue: ({scopeDescriptor, bufferPosition, prefix, editor}) ->
     scopes = scopeDescriptor.getScopesArray()


### PR DESCRIPTION
Using `__dirname` inside the snapshot will return a relative path, which will cause this package to fail to load completions from `{packageRoot}/completions.json`. With this pull request we use the `require` system to load such file so that it can be snapshotted; doing so will fix the aforementioned error and will improve performance as well because we will save a file system call.