### PR TITLE
Do not autocomplete after finishing a percentage

### DIFF
--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -195,7 +195,10 @@ module.exports =
     if @isPropertyValuePrefix(prefix)
       for value in values when firstCharsEqual(value, prefix)
         completions.push(@buildPropertyValueCompletion(value, property, addSemicolon))
-    else
+    else if not hasScope(scopes, 'keyword.other.unit.percentage.css') and # CSS
+    not hasScope(scopes, 'keyword.other.unit.scss') and # SCSS (TODO: remove in Atom 1.19.0)
+    not hasScope(scopes, 'keyword.other.unit.css') # Less, Sass (TODO: remove in Atom 1.19.0)
+      # Don't complete here: `width: 100%|`
       for value in values
         completions.push(@buildPropertyValueCompletion(value, property, addSemicolon))
 

--- a/spec/provider-spec.coffee
+++ b/spec/provider-spec.coffee
@@ -323,6 +323,16 @@ describe "CSS property name and value autocompletions", ->
         expect(completions).toHaveLength 1
         expect(completions[0].text).toBe 'center;'
 
+      it "does not complete property values after percentage signs", ->
+        editor.setText """
+          body {
+            width: 100%
+          }
+        """
+        editor.setCursorBufferPosition([1, 13])
+        completions = getCompletions()
+        expect(completions).toHaveLength 0
+
       it "it doesn't add semicolon after a property if one is already present", ->
         editor.setText """
           body {


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Do not autocomplete property values here: `width: 100%|`.

### Alternate Designs

Adjusting ac+'s default prefix to include the percentage sign.

### Benefits

No useless completions after a percent.

### Possible Drawbacks

None?

### Applicable Issues

Fixes #96