### PR TITLE
Enable autocompletion for Stylus.

### DIFF
--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -22,7 +22,6 @@ module.exports =
   filterSuggestions: true
 
   getSuggestions: (request) ->
-    console.log(request)
     completions = null
     scopes = request.scopeDescriptor.getScopesArray()
     isSass = hasScope(scopes, 'source.sass', true) or hasScope(scopes, 'source.css.stylus')

--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -68,7 +68,7 @@ module.exports =
     (hasScope(previousScopesArray, 'meta.property-value.scss')) or
     (hasScope(scopes, 'meta.property-list.postcss') and prefix.trim() is ":") or
     (hasScope(previousScopesArray, 'meta.property-value.postcss')) or
-    ((hasScope(scopes, 'source.sass', true) or hasScope('source.css.stylus')) and ((hasScope(scopes, 'meta.property-value.sass') or hasScope(scopes, 'meta.property-value.css')) or
+    ((hasScope(scopes, 'source.sass', true) or hasScope(scopes, 'source.css.stylus')) and ((hasScope(scopes, 'meta.property-value.sass') or hasScope(scopes, 'meta.property-value.css')) or
       (not hasScope(beforePrefixScopesArray, 'entity.name.tag.css') and prefix.trim() is ":")
     ))
 

--- a/spec/provider-spec.coffee
+++ b/spec/provider-spec.coffee
@@ -905,3 +905,281 @@ describe "CSS property name and value autocompletions", ->
           text = (completion.text or completion.snippet)
           expect(text.length).toBeGreaterThan 0
           expect(completion.type).toBe 'pseudo-selector'
+
+  describe "Stylus files", ->
+    beforeEach ->
+      waitsForPromise -> atom.packages.activatePackage('Stylus')
+      waitsForPromise -> atom.workspace.open('test.styl')
+      runs -> editor = atom.workspace.getActiveTextEditor()
+
+    it "autocompletes property names with a prefix", ->
+      editor.setText """
+        body
+          d
+      """
+      editor.setCursorBufferPosition([1, 3])
+      completions = getCompletions()
+      expect(completions[0].text).toBe 'display '
+      expect(completions[0].displayText).toBe 'display'
+      expect(completions[0].type).toBe 'property'
+      expect(completions[0].replacementPrefix).toBe 'd'
+      expect(completions[0].description.length).toBeGreaterThan 0
+      expect(completions[0].descriptionMoreURL.length).toBeGreaterThan 0
+      expect(completions[1].text).toBe 'direction '
+      expect(completions[1].displayText).toBe 'direction'
+      expect(completions[1].type).toBe 'property'
+      expect(completions[1].replacementPrefix).toBe 'd'
+
+      editor.setText """
+        body
+          D
+      """
+      editor.setCursorBufferPosition([1, 3])
+      completions = getCompletions()
+      expect(completions.length).toBe 2
+      expect(completions[0].text).toBe 'display '
+      expect(completions[1].text).toBe 'direction '
+      expect(completions[1].replacementPrefix).toBe 'D'
+
+      editor.setText """
+        body
+          d
+      """
+      editor.setCursorBufferPosition([1, 3])
+      completions = getCompletions()
+      expect(completions[0].text).toBe 'display '
+      expect(completions[1].text).toBe 'direction '
+
+      editor.setText """
+        body
+          bord
+      """
+      editor.setCursorBufferPosition([1, 6])
+      completions = getCompletions()
+      expect(completions[0].text).toBe 'border '
+      expect(completions[0].displayText).toBe 'border'
+      expect(completions[0].replacementPrefix).toBe 'bord'
+
+    it "triggers autocomplete when an property name has been inserted", ->
+      spyOn(atom.commands, 'dispatch')
+      suggestion = {type: 'property', text: 'whatever'}
+      provider.onDidInsertSuggestion({editor, suggestion})
+
+      advanceClock 1
+      expect(atom.commands.dispatch).toHaveBeenCalled()
+
+      args = atom.commands.dispatch.mostRecentCall.args
+      expect(args[0].tagName.toLowerCase()).toBe 'atom-text-editor'
+      expect(args[1]).toBe 'autocomplete-plus:activate'
+
+    it "autocompletes property values without a prefix", ->
+      editor.setText """
+        body
+          display:
+      """
+      editor.setCursorBufferPosition([1, 10])
+      completions = getCompletions()
+      expect(completions.length).toBe 24
+      for completion in completions
+        expect(completion.text.length).toBeGreaterThan 0
+        expect(completion.description.length).toBeGreaterThan 0
+        expect(completion.descriptionMoreURL.length).toBeGreaterThan 0
+
+      editor.setText """
+        body
+          display:
+      """
+      editor.setCursorBufferPosition([2, 0])
+      completions = getCompletions()
+      expect(completions.length).toBe 24
+      for completion in completions
+        expect(completion.text.length).toBeGreaterThan 0
+
+    it "autocompletes property values with a prefix", ->
+      editor.setText """
+        body
+          display: i
+      """
+      editor.setCursorBufferPosition([1, 12])
+      completions = getCompletions()
+      expect(completions[0].text).toBe 'inline'
+      expect(completions[0].description.length).toBeGreaterThan 0
+      expect(completions[0].descriptionMoreURL.length).toBeGreaterThan 0
+      expect(completions[1].text).toBe 'inline-block'
+      expect(completions[2].text).toBe 'inline-flex'
+      expect(completions[3].text).toBe 'inline-grid'
+      expect(completions[4].text).toBe 'inline-table'
+      expect(completions[5].text).toBe 'inherit'
+
+      editor.setText """
+        body
+          display: I
+      """
+      editor.setCursorBufferPosition([1, 12])
+      completions = getCompletions()
+      expect(completions.length).toBe 6
+      expect(completions[0].text).toBe 'inline'
+      expect(completions[1].text).toBe 'inline-block'
+      expect(completions[2].text).toBe 'inline-flex'
+      expect(completions[3].text).toBe 'inline-grid'
+      expect(completions[4].text).toBe 'inline-table'
+      expect(completions[5].text).toBe 'inherit'
+
+    it "autocompletes !important in property-value scope", ->
+      editor.setText """
+        body
+          display: inherit !im
+      """
+      editor.setCursorBufferPosition([1, 22])
+      completions = getCompletions()
+
+      important = null
+      for c in completions
+        important = c if c.displayText is '!important'
+
+      expect(important.displayText).toBe '!important'
+
+    it "does not autocomplete when indented and prefix is not a char", ->
+      editor.setText """
+        body
+          .
+      """
+      editor.setCursorBufferPosition([1, 3])
+      completions = getCompletions(activatedManually: false)
+      expect(completions.length).toBe 0
+
+      editor.setText """
+        body
+          #
+      """
+      editor.setCursorBufferPosition([1, 3])
+      completions = getCompletions(activatedManually: false)
+      expect(completions.length).toBe 0
+
+      editor.setText """
+        body
+          .foo,
+      """
+      editor.setCursorBufferPosition([1, 7])
+      completions = getCompletions(activatedManually: false)
+      expect(completions).toBe null
+
+      editor.setText """
+        body
+          foo -
+      """
+      editor.setCursorBufferPosition([1, 8])
+      completions = getCompletions(activatedManually: false)
+      expect(completions).toBe null
+
+      # As spaces at end of line will be removed, we'll test with a char
+      # after the space and with the cursor before that char.
+      editor.setCursorBufferPosition([1, 7])
+      completions = getCompletions(activatedManually: false)
+      expect(completions).toBe null
+
+    it 'does not autocomplete when inside a nth-child selector', ->
+      editor.setText """
+        body
+          &:nth-child(4
+      """
+      editor.setCursorBufferPosition([1, 15])
+      completions = getCompletions(activatedManually: false)
+      expect(completions).toBe null
+
+    it 'autocompletes a property name with a dash', ->
+      editor.setText """
+        body
+          border-
+      """
+      editor.setCursorBufferPosition([1, 9])
+      completions = getCompletions(activatedManually: false)
+      expect(completions).not.toBe null
+
+      expect(completions[0].text).toBe 'border '
+      expect(completions[0].displayText).toBe 'border'
+      expect(completions[0].replacementPrefix).toBe 'border-'
+
+      expect(completions[1].text).toBe 'border-radius '
+      expect(completions[1].displayText).toBe 'border-radius'
+      expect(completions[1].replacementPrefix).toBe 'border-'
+
+    it "does not autocomplete !important in property-name scope", ->
+      editor.setText """
+        body {
+          !im
+        }
+      """
+      editor.setCursorBufferPosition([1, 5])
+      completions = getCompletions()
+
+      important = null
+      for c in completions
+        important = c if c.displayText is '!important'
+
+      expect(important).toBe null
+
+    describe "tags", ->
+      it "autocompletes with a prefix", ->
+        editor.setText """
+          ca
+        """
+        editor.setCursorBufferPosition([0, 2])
+        completions = getCompletions()
+        expect(completions.length).toBe 7
+        expect(completions[0].text).toBe 'canvas'
+        expect(completions[0].type).toBe 'tag'
+        expect(completions[0].description).toBe 'Selector for <canvas> elements'
+        expect(completions[1].text).toBe 'code'
+
+        editor.setText """
+          canvas,ca
+        """
+        editor.setCursorBufferPosition([0, 9])
+        completions = getCompletions()
+        expect(completions.length).toBe 7
+        expect(completions[0].text).toBe 'canvas'
+
+        editor.setText """
+          canvas ca
+        """
+        editor.setCursorBufferPosition([0, 9])
+        completions = getCompletions()
+        expect(completions.length).toBe 7
+        expect(completions[0].text).toBe 'canvas'
+
+        editor.setText """
+          canvas, ca
+        """
+        editor.setCursorBufferPosition([0, 10])
+        completions = getCompletions()
+        expect(completions.length).toBe 7
+        expect(completions[0].text).toBe 'canvas'
+
+      it "does not autocomplete when prefix is preceded by class or id char", ->
+        editor.setText """
+          .ca
+        """
+        editor.setCursorBufferPosition([0, 3])
+        completions = getCompletions()
+        expect(completions).toBe null
+
+        editor.setText """
+          #ca
+        """
+        editor.setCursorBufferPosition([0, 3])
+        completions = getCompletions()
+        expect(completions).toBe null
+
+    describe "pseudo selectors", ->
+      it "autocompletes without a prefix", ->
+        editor.setText """
+          div:
+        """
+        editor.setCursorBufferPosition([0, 4])
+        completions = getCompletions()
+        expect(completions.length).toBe 43
+        for completion in completions
+          text = (completion.text or completion.snippet)
+          expect(text.length).toBeGreaterThan 0
+          expect(completion.type).toBe 'pseudo-selector'


### PR DESCRIPTION
### Description of the Change
Adds functionality to check against the `source.css.stylus` scope provided by the popular (and only really complete) [`language-stylus`](https://github.com/matthojo/language-stylus) package and provide completions in the form of `property-name value`.

![screenflow](https://user-images.githubusercontent.com/2207980/31068243-3209339a-a725-11e7-9cf2-2bf198dbc20a.gif)

### Alternate Designs
N/A

### Benefits
Stylus users enjoy this package's invaluable features.

### Possible Drawbacks
None that I've seen so far!

### Applicable Issues
💖 